### PR TITLE
Installation breaks due to wrong package.json engine version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/medikoo/modules-webmake/issues"
   },
   "engines": {
-    "node": ">=0.4"
+    "node": ">=0.8"
   },
   "dependencies": {
     "deferred": "0.6.x",


### PR DESCRIPTION
Tested on node v0.6.15 - installation of modules-webmake breaks with NPM complaining about version incomaibility. It seems fs2 requires at least node v0.8. Upgrading node solves the problem, but the package info is a bit confusing.
