### PR TITLE
Add ignore feature so that some special require statement can be ignored.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Expose bundle as AMD module. If used together with _[name](#name-string)_ option
 Additional module(s) that should be included but due specific reasons are
 not picked by parser (can be set multiple times)
 
+##### ignores `string`
+
+Module path(s) that should be ignored (Mostly for cases on ignoring some require statement in external libaries) (can be set multiple times)
+
 ##### ext `string`
 
 Additional extensions(s) that should be used for modules resolution from custom formats e.g. _coffee-script_ or _yaml_.  

--- a/bin/webmake
+++ b/bin/webmake
@@ -28,6 +28,11 @@ var count     = require('es5-ext/lib/Object/count')
 			description: "Additional module(s) that should be included (and are" +
 				" not picked by the parser)"
 		},
+		ignores: {
+			string: true,
+			description: "Module path(s) that be ignored (but are " +
+				"picked by the parser and cannot be handled)"
+		},
 		help: {
 			boolean: true,
 			desription: "Show this help"
@@ -52,6 +57,12 @@ if (argv.include) {
 	options.include = argv.include;
 	if (!isArray(options.include)) {
 		options.include = [options.include];
+	}
+}
+if (argv.ignores) {
+	options.ignores = argv.ignores;
+	if (!Array.isArray(options.ignores)) {
+		options.ignores = [options.ignores];
 	}
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -35,9 +35,12 @@ if (sep == null) {
 }
 dirEndMatch = new RegExp('(?:^|\\' + sep + ')\\.*$');
 
-parseDependencies = function (text, filename) {
+parseDependencies = function (text, filename, ignores) {
 	return findRequires(text, { raw: true }).map(function (node) {
 		var path = node.value;
+		if (ignores.indexOf(node.raw) > -1) {
+			return node.raw;
+		}
 		if (!path) {
 			throw new TypeError("Not supported require call: " + node.raw +
 				" at " + filename + ":" + node.line);
@@ -79,7 +82,7 @@ stripBOM = function (source) {
 	return source;
 };
 
-readFileData = function (filename, parser, localFilename) {
+readFileData = function (filename, parser, localFilename, ignores) {
 	return readFile(filename, readFileOpts)(function (code) {
 		var ext = extname(filename), noDeps, deps;
 		code = stripBOM(code);
@@ -97,7 +100,7 @@ readFileData = function (filename, parser, localFilename) {
 		}
 
 		if (sLast.call(code) !== '\n') code += '\n';
-		deps = noDeps ? [] : parseDependencies(code, filename);
+		deps = noDeps ? [] : parseDependencies(code, filename, ignores);
 
 		if (parser.sourceMap) {
 			code = 'eval(' + stringify(code + '//@ sourceURL=' +
@@ -109,7 +112,7 @@ readFileData = function (filename, parser, localFilename) {
 
 readFileDataCached = (function () {
 	var cache = {};
-	return function (filename, parser, localFilename) {
+	return function (filename, parser, localFilename, ignores) {
 		var data;
 		if (!cache.hasOwnProperty(filename)) data = cache[filename] = {};
 		else data = cache[filename];
@@ -117,7 +120,7 @@ readFileDataCached = (function () {
 			stats = stats.size + '.' + stats.mtime.valueOf();
 			if (data.stats === stats) return data.data;
 			data.stats = stats;
-			return (data.data = readFileData(filename, parser, localFilename));
+			return (data.data = readFileData(filename, parser, localFilename, ignores));
 		});
 	};
 }());
@@ -146,7 +149,9 @@ modulesToString = function self(nest, parser) {
 };
 
 parser = {
-	readInput: function (input) {
+	ignorePaths: [],
+	readInput: function (input, ignores) {
+		this.ignorePaths = this.ignorePaths.concat(ignores || []);
 		var scope, path, tree = [];
 		input = resolve(String(input));
 		statsCache = {};
@@ -176,7 +181,7 @@ parser = {
 		// console.log("PC", filename);
 		var read = this.cache ? readFileDataCached : readFileData;
 		return read(filename, this,
-			filename.split(sep).slice(-2 - tree.length).join('/'))(function (data) {
+			filename.split(sep).slice(-2 - tree.length).join('/'), this.ignorePaths)(function (data) {
 			this.modulesFiles.push(filename);
 			scope[name] = data.content;
 			return deferred.map(data.deps,
@@ -186,6 +191,9 @@ parser = {
 	resolve: function (fromfile, dirname, scope, tree, filename) {
 		// console.log("R", filename);
 		tree = copy.call(tree);
+		if (this.ignorePaths.indexOf(filename) > -1) {
+			return '';
+		}
 		if (filename[0] === '.') {
 			return this.resolveLocal(fromfile, dirname, scope, tree, filename);
 		} else {

--- a/lib/webmake.js
+++ b/lib/webmake.js
@@ -40,7 +40,7 @@ module.exports = function (input, options, cb) {
 	}
 	time = now();
 	parser = createParser(options);
-	promise = parser.readInput(input)(function (path) {
+	promise = parser.readInput(input, options.ignores || [])(function (path) {
 		return deferred.map([].concat(options.include || []), function (path) {
 			path = resolve(String(path));
 			return filesAtPath(path).invoke('filter', function (filename) {

--- a/test/__playground/lib/exclude.js
+++ b/test/__playground/lib/exclude.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function getC(key) {
+    return require('./included/' + key).name;
+}
+
+exports.getC = getC;

--- a/test/__playground/lib/included/c.js
+++ b/test/__playground/lib/included/c.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.name = 'included.c';

--- a/test/__playground/lib/program.js
+++ b/test/__playground/lib/program.js
@@ -20,7 +20,8 @@ require('./nl-comment')(exports);
 
 exports.included = {
 	a: indirectRequire('./included/a'),
-	b: indirectRequire('./included/b')
+	b: indirectRequire('./included/b'),
+    c: indirectRequire('./included/c')
 };
 
 exports.external = {
@@ -28,3 +29,5 @@ exports.external = {
 	other: require('test/lib/other.js'),
 	noMain: require('no-main/lib/some-module')
 };
+
+exports.getC = require('./exclude').getC;

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,7 +9,7 @@ module.exports = {
 		var input, parser;
 		input = resolve(pg, 'lib/program.js');
 		parser = t();
-		parser.readInput(input)(function (path) {
+		parser.readInput(input, ["'./included/' + key"])(function (path) {
 			a(path, "__playground/lib/program", "Path");
 			a.deep(Object.keys(parser.modules).sort(),
 				['__playground', 'no-main', 'path', 'test'], "Modules");

--- a/test/webmake.js
+++ b/test/webmake.js
@@ -14,7 +14,7 @@ module.exports = {
 	"": function (t, a, d) {
 		var input = pg + '/lib/program.js'
 		  , output = pg + '/build.js'
-		  , options = { include: pg + '/lib/included' };
+		  , options = { include: pg + '/lib/included', ignores: ["'./included/' + key"]};
 		t = promisify(t);
 		t(input, options)(function (result) {
 			var program = runInNewContext(result, {});
@@ -57,6 +57,9 @@ module.exports = {
 				"cztery": null, "osiem:": undefined }, "JSON");
 
 			a(program.circularOther, 'circTest', "Partially broken dependecy test");
+
+			a(program.getC('c'), 'included.c', 'File contains exclude file');
+			a(program.included.c.name, 'included.c', "Manually included #3");
 
 			options.output = output;
 			return t(input, options)(lock.call(readFile, output, 'utf8'))(


### PR DESCRIPTION
The use case is when I am writing my own date-util.js which requires moment.js,
one speical require statement in moment.js cannot be handled by webmake:
require('./lang/' + key);

The purpose of wrapping moment.js to my own libary is for easier swapping to
another libary in the future if needed.

Hence, ignoring that special require and manually include some language file
can be enough.
