### PR TITLE
fix: filename contain @ bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = function (input, options, cb) {
 	const time = now();
 	const parser = createParser(options);
 	const promise = parser
-		.readInput(input, options)(path =>
+		.readInput(
+			input, options
+		)(path =>
 			deferred.map([].concat(options.include || []), inputPath => {
 				inputPath = resolve(String(inputPath));
 				return filesAtPath(inputPath)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -481,7 +481,12 @@ const parser = {
 		const org = dep.value, lScope = scope;
 		let filename = join(dep.value), tree, currentRequire, main, path, ext;
 
-		const [name] = filename.split(sep, 1);
+		let [name] = filename.split(sep, 1);
+		// container @xxx/
+		if (/^@.+\/.+/u.test(filename)) {
+			name = filename;
+		}
+
 		return deferred.promisifySync(() => {
 			// If already processed, return result
 			if (this.modules[name]) return this.modules[name];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -105,7 +105,9 @@ const stripBOM = function (source) {
 };
 
 const getMain = memoize(path =>
-	readFile(resolve(path, "package.json"), readFileOpts)(content => {
+	readFile(
+		resolve(path, "package.json"), readFileOpts
+	)(content => {
 		const { main } = parse(stripBOM(content));
 		if (!main) throw new Error("No main setting found");
 		return main;
@@ -223,9 +225,9 @@ const readFileContent = function (code, filename, fileParser, localFilename) {
 };
 
 const readFileData = function (filename, fileParser, localFilename) {
-	return readFile(filename, readFileOpts)(code =>
-		readFileContent(code, filename, fileParser, localFilename)
-	);
+	return readFile(
+		filename, readFileOpts
+	)(code => readFileContent(code, filename, fileParser, localFilename));
 };
 
 const readFileDataCached = (function () {
@@ -308,7 +310,9 @@ const parser = {
 				return result;
 			}
 			return def.promise(fileContent =>
-				readFileContent(fileContent, name, this, name)(data => {
+				readFileContent(
+					fileContent, name, this, name
+				)(data => {
 					scope[name] = data.content;
 					return deferred.map(
 						data.deps, this.resolve.bind(this, input, dirname(input), scope, [])
@@ -320,7 +324,9 @@ const parser = {
 	readFile(filename, name, scope, tree) {
 		log.debug("read %s", filename);
 		const read = this.cache ? readFileDataCached : readFileData;
-		return read(filename, this, filename.split(sep).slice(-2 - tree.length).join("/"))(data => {
+		return read(
+			filename, this, filename.split(sep).slice(-2 - tree.length).join("/")
+		)(data => {
 			this.modulesFiles.push(filename);
 			scope[name] = data.content;
 			return deferred

--- a/lib/webmake.tpl
+++ b/lib/webmake.tpl
@@ -82,6 +82,10 @@
 			tree = [];
 		} else if (t !== '.') {
 			name = path.split('/', 1)[0];
+			// container @xxx/
+			if (/^@.+\/.+/u.test(path)) {
+					name = path
+			}
 			scope = modules[name];
 			if (!scope) {
 				if (envRequire) return envRequire(fullPath);

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,9 @@ module.exports = {
 		    , output = `${ pg }/build.js`
 		    , options = { include: `${ pg }/lib/included`, ignore: [resolve(pg, "not-taken.js")] };
 		t = promisify(t);
-		t(input, options)(result => {
+		t(
+			input, options
+		)(result => {
 			const program = runInNewContext(result, {});
 			a(program.x.name, "x", "Same path require");
 			a(program.x.getZ().name, "z", "Deferred call");
@@ -122,7 +124,9 @@ module.exports = {
 		const input = `${ pg }/lib/other-type-includes.js`
 		    , options = { include: `${ pg }/includes` };
 		t = promisify(t);
-		t(input, options)(result => {
+		t(
+			input, options
+		)(result => {
 			const program = runInNewContext(result, browserContext, input);
 			a(program.html, "<div>HTML</div>\n", "Same path require");
 		}).done(d, d);

--- a/test/lib/browser/__tad.js
+++ b/test/lib/browser/__tad.js
@@ -2,7 +2,7 @@
 
 let jsdomDocument;
 
-try { jsdomDocument = new (require("jsdom")).JSDOM().window.document; }
+try { jsdomDocument = new (require("jsdom").JSDOM)().window.document; }
 catch (ignore) {}
 
 if (jsdomDocument) {


### PR DESCRIPTION
When npm modules name like `@slsplus/tencent-serverless-http`,  `parser.resolveExternal` function will failed. Because it ignore `@slsplus` directly.